### PR TITLE
Four super-resolution models have been introduced

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -4,7 +4,7 @@ from tensorflow.keras.callbacks import EarlyStopping
 
 from utils.callbacks import ModelCheckpoint, TimeHistory
 from engine.metrics import (jaccard_index, jaccard_index_softmax, IoU_instances, instance_segmentation_loss, weighted_bce_dice_loss,
-                            masked_bce_loss, masked_jaccard_index, PSNR, n2v_loss_mse, MAE_instances)
+                            masked_bce_loss, masked_jaccard_index, PSNR, dfcan_loss, n2v_loss_mse, MAE_instances)
 
 
 def prepare_optimizer(cfg, model):
@@ -74,8 +74,12 @@ def prepare_optimizer(cfg, model):
         model.compile(optimizer=opt, loss=instance_segmentation_loss(cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNEL_WEIGHTS, cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS),
                       metrics=metrics)   
     elif cfg.PROBLEM.TYPE in ["SUPER_RESOLUTION", "SELF_SUPERVISED"]:
-        print("Overriding 'LOSS.TYPE' to set it to MAE")
-        model.compile(optimizer=opt, loss="mae", metrics=[PSNR])
+        if cfg.MODEL.ARCHITECTURE == 'dfcan':
+            print("Overriding 'LOSS.TYPE' to set it to DFCAN loss")
+            model.compile(optimizer=opt, loss=[dfcan_loss()], metrics=[PSNR])
+        else:
+            print("Overriding 'LOSS.TYPE' to set it to MAE")
+            model.compile(optimizer=opt, loss="mae", metrics=[PSNR])
         metric_name.append("PSNR")
     elif cfg.PROBLEM.TYPE == "DENOISING":
         print("Overriding 'LOSS.TYPE' to set it to N2V loss (masked MSE)")

--- a/engine/check_configuration.py
+++ b/engine/check_configuration.py
@@ -283,7 +283,8 @@ def check_configuration(cfg):
 
     ### Model ###
     assert cfg.MODEL.ARCHITECTURE in ['unet', 'resunet', 'attention_unet', 'fcn32', 'fcn8', 'tiramisu', 'mnet',
-                                      'multiresunet', 'seunet', 'simple_cnn', 'EfficientNetB0', 'unetr', 'edsr']
+                                      'multiresunet', 'seunet', 'simple_cnn', 'EfficientNetB0', 'unetr', 'edsr',
+                                      'srunet', 'rcan', 'dfcan', 'wdsr']
     if cfg.MODEL.ARCHITECTURE not in ['unet', 'resunet', 'seunet', 'attention_unet'] and cfg.PROBLEM.NDIM == '3D' and cfg.PROBLEM.TYPE != "CLASSIFICATION":
         raise ValueError("For 3D these models are available: {}".format(['unet', 'resunet', 'seunet', 'attention_unet']))
     if cfg.MODEL.ARCHITECTURE == "unetr":
@@ -307,8 +308,8 @@ def check_configuration(cfg):
         cfg.MODEL.ARCHITECTURE not in ['unet', 'resunet', 'seunet', 'attention_unet']:
         raise ValueError("Architectures available for {} are: ['unet', 'resunet', 'seunet', 'attention_unet']"
                          .format(cfg.PROBLEM.TYPE))
-    if cfg.PROBLEM.TYPE == 'SUPER_RESOLUTION' and cfg.MODEL.ARCHITECTURE not in ['edsr']:
-        raise ValueError("Architectures available for 'SUPER_RESOLUTION' are: ['edsr']")
+    if cfg.PROBLEM.TYPE == 'SUPER_RESOLUTION' and cfg.MODEL.ARCHITECTURE not in ['edsr', 'srunet', 'rcan', 'dfcan', 'wdsr']:
+        raise ValueError("Architectures available for 'SUPER_RESOLUTION' are: ['edsr', 'srunet', 'rcan', 'dfcan', 'wdsr']")
     if cfg.PROBLEM.TYPE == 'CLASSIFICATION' and cfg.MODEL.ARCHITECTURE not in ['simple_cnn', 'EfficientNetB0']:
         raise ValueError("Architectures available for 'CLASSIFICATION' are: ['simple_cnn', 'EfficientNetB0']")
     if cfg.MODEL.ARCHITECTURE == "unetr" and cfg.TEST.STATS.FULL_IMG:

--- a/engine/metrics.py
+++ b/engine/metrics.py
@@ -698,6 +698,17 @@ def PSNR(super_resolution, high_resolution, max_val=255):
     psnr_value = tf.image.psnr(high_resolution, super_resolution, max_val=max_val)[0]
     return psnr_value
 
+## Loss function definition used in the paper from nature methods:
+### [Chang Qiao](https://github.com/qc17-THU/DL-SR/tree/main/src) (MIT license).
+def dfcan_loss(max_val=255):
+	def mse_ssim(y_true, y_pred):
+		mse = tf.keras.losses.MeanSquaredError()
+		ssim = tf.image.ssim(y_true, y_pred, max_val=max_val)
+		res = mse(y_true, y_pred) + 0.1*(1-ssim)
+		return res
+	
+	return mse_ssim
+	
 def n2v_loss_mse():
     def n2v_mse(y_true, y_pred):
         target, mask = tf.split(y_true, 2, axis=len(y_true.shape)-1)

--- a/models/dfcan.py
+++ b/models/dfcan.py
@@ -1,0 +1,292 @@
+import tensorflow as tf
+import numpy as np
+from tensorflow.keras import layers
+from tensorflow.keras import backend as K
+from tensorflow.keras.models import Model
+
+class DFCANModel(tf.keras.Model):
+    """
+    	Code copied from https://keras.io/examples/vision/edsr
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dtype_not_set = False
+        self.max_value = 255
+        self.out_dtype = tf.uint8
+
+    def train_step(self, data):
+        # Unpack the data. Its structure depends on your model and
+        # on what you pass to `fit()`.
+        x, y = data
+
+        if not self.dtype_not_set:
+            if y.dtype == tf.uint16:
+                self.max_value = 65535 
+            self.out_dtype = y.dtype 
+            self.dtype_not_set = True
+
+        with tf.GradientTape() as tape:
+            y_pred = self(x, training=True)  # Forward pass 
+            y_pred = y_pred*255
+
+            # Compare always in [0-255] range
+            if y.dtype == tf.uint16:
+                y = tf.cast((y/65535)*255, tf.uint8)
+            
+            # Compute the loss value
+            # (the loss function is configured in `compile()`)
+            loss = self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        # Update metrics (includes the metric that tracks the loss)
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value
+        return {m.name: m.result() for m in self.metrics}
+
+    def test_step(self, data):
+        # Unpack the data
+        x, y = data
+        # Compute predictions
+        y_pred = self(x, training=False)
+        y_pred = y_pred*255
+
+        # Compare always in [0-255] range
+        if y.dtype == tf.uint16:
+            y = tf.cast((y/65535)*255, tf.uint8)
+
+        # Updates the metrics tracking the loss
+        self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+        # Update the metrics.
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {m.name: m.result() for m in self.metrics}
+
+    def predict_step(self, x):
+        # Always return the same image dtype and value range of the ground truth
+        # if gt is uint16 -> return uint16 image with values between [0,65535]
+        # if gt is uint8 -> return uint8 image with values between [0,255]
+
+        # Passing low resolution image to model
+        super_resolution_img = self(x, training=False)  
+        super_resolution_img = tf.clip_by_value(super_resolution_img, 0, 1)
+        super_resolution_img = super_resolution_img*self.max_value
+        super_resolution_img = tf.cast(super_resolution_img, self.out_dtype)
+        
+        return super_resolution_img 
+ 
+    def set_dtype(self, img):
+        if not self.dtype_not_set:
+            if img.dtype == np.uint16:
+                self.max_value = 65535
+                self.out_dtype = tf.uint16
+            self.dtype_not_set = True
+
+## Loss function definition used in the paper from nature methods
+def loss_dfcan(y_true, y_pred):
+  mse = tf.keras.losses.MeanSquaredError()
+  ssim = tf.image.ssim_multiscale(y_true, y_pred, max_val=1)
+  res = mse(y_true, y_pred) + 0.1*(1-ssim)
+  return res
+
+## DFCAN network definition. We follow the code from:
+### [Chang Qiao](https://github.com/qc17-THU/DL-SR/tree/main/src) (MIT license).
+#### Common methods for both DFCAN and DFGAN adapted from `common.py`:
+
+
+def gelu(x):
+    cdf = 0.5 * (1.0 + tf.math.erf(x / tf.sqrt(2.0)))
+    return x * cdf
+
+
+def fft2d(input, gamma=0.1):
+    temp = K.permute_dimensions(input, (0, 3, 1, 2))
+    fft = tf.signal.fft2d(tf.complex(temp, tf.zeros_like(temp)))
+    absfft = tf.math.pow(tf.math.abs(fft)+1e-8, gamma)
+    output = K.permute_dimensions(absfft, (0, 2, 3, 1))
+    return output
+
+
+def fft3d(input, gamma=0.1):
+    input = apodize3d(input, napodize=5)
+    temp = K.permute_dimensions(input, (0, 4, 1, 2, 3))
+    fft = tf.fft3d(tf.complex(temp, tf.zeros_like(temp)))
+    absfft = tf.math.pow(tf.math.abs(fft) + 1e-8, gamma)
+    output = K.permute_dimensions(absfft, (0, 2, 3, 4, 1))
+    return output
+
+
+def fftshift2d(input, size_psc):
+    bs, h, w, ch = input.get_shape().as_list()
+    fs11 = input[:, -h // 2:h, -w // 2:w, :]
+    fs12 = input[:, -h // 2:h, 0:w // 2, :]
+    fs21 = input[:, 0:h // 2, -w // 2:w, :]
+    fs22 = input[:, 0:h // 2, 0:w // 2, :]
+    output = tf.concat([tf.concat([fs11, fs21], axis=1), tf.concat([fs12, fs22], axis=1)], axis=2)
+    output = tf.image.resize(output, (size_psc, size_psc))
+    return output
+
+
+def fftshift3d(input, size_psc=64):
+    bs, h, w, z, ch = input.get_shape().as_list()
+    fs111 = input[:, -h // 2:h, -w // 2:w, -z // 2 + 1:z, :]
+    fs121 = input[:, -h // 2:h, 0:w // 2, -z // 2 + 1:z, :]
+    fs211 = input[:, 0:h // 2, -w // 2:w, -z // 2 + 1:z, :]
+    fs221 = input[:, 0:h // 2, 0:w // 2, -z // 2 + 1:z, :]
+    fs112 = input[:, -h // 2:h, -w // 2:w, 0:z // 2 + 1, :]
+    fs122 = input[:, -h // 2:h, 0:w // 2, 0:z // 2 + 1, :]
+    fs212 = input[:, 0:h // 2, -w // 2:w, 0:z // 2 + 1, :]
+    fs222 = input[:, 0:h // 2, 0:w // 2, 0:z // 2 + 1, :]
+    output1 = tf.concat([tf.concat([fs111, fs211], axis=1), tf.concat([fs121, fs221], axis=1)], axis=2)
+    output2 = tf.concat([tf.concat([fs112, fs212], axis=1), tf.concat([fs122, fs222], axis=1)], axis=2)
+    output0 = tf.concat([output1, output2], axis=3)
+    output = []
+    for iz in range(z):
+        output.append(tf.image.resize(output0[:, :, :, iz, :], (size_psc, size_psc)))
+    output = tf.stack(output, axis=3)
+    return output
+
+
+def apodize2d(img, napodize=10):
+    bs, ny, nx, ch = img.get_shape().as_list()
+    img_apo = img[:, napodize:ny-napodize, :, :]
+
+    imageUp = img[:, 0:napodize, :, :]
+    imageDown = img[:, ny-napodize:, :, :]
+    diff = (imageDown[:, -1::-1, :, :] - imageUp) / 2
+    l = np.arange(napodize)
+    fact_raw = 1 - np.sin((l + 0.5) / napodize * np.pi / 2)
+    fact = fact_raw[np.newaxis, :, np.newaxis, np.newaxis]
+    fact = tf.convert_to_tensor(fact, dtype=tf.float32)
+    fact = tf.tile(fact, [tf.shape(img)[0], 1, nx, ch])
+    factor = diff * fact
+    imageUp = tf.add(imageUp, factor)
+    imageDown = tf.subtract(imageDown, factor[:, -1::-1, :, :])
+    img_apo = tf.concat([imageUp, img_apo, imageDown], axis=1)
+
+    imageLeft = img_apo[:, :, 0:napodize, :]
+    imageRight = img_apo[:, :, nx-napodize:, :]
+    img_apo = img_apo[:, :, napodize:nx-napodize, :]
+    diff = (imageRight[:, :, -1::-1, :] - imageLeft) / 2
+    fact = fact_raw[np.newaxis, np.newaxis, :, np.newaxis]
+    fact = tf.convert_to_tensor(fact, dtype=tf.float32)
+    fact = tf.tile(fact, [tf.shape(img)[0], ny, 1, ch])
+    factor = diff * fact
+    imageLeft = tf.add(imageLeft, factor)
+    imageRight = tf.subtract(imageRight, factor[:, :, -1::-1, :])
+    img_apo = tf.concat([imageLeft, img_apo, imageRight], axis=2)
+
+    return img_apo
+
+
+def apodize3d(img, napodize=5):
+    bs, ny, nx, nz, ch = img.get_shape().as_list()
+    img_apo = img[:, napodize:ny-napodize, :, :, :]
+
+    imageUp = img[:, 0:napodize, :, :, :]
+    imageDown = img[:, ny-napodize:, :, :, :]
+    diff = (imageDown[:, -1::-1, :, :, :] - imageUp) / 2
+    l = np.arange(napodize)
+    fact_raw = 1 - np.sin((l + 0.5) / napodize * np.pi / 2)
+    fact = fact_raw[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
+    fact = tf.convert_to_tensor(fact, dtype=tf.float32)
+    fact = tf.tile(fact, [tf.shape(img)[0], 1, nx, nz, ch])
+    factor = diff * fact
+    imageUp = tf.add(imageUp, factor)
+    imageDown = tf.subtract(imageDown, factor[:, -1::-1, :, :, :])
+    img_apo = tf.concat([imageUp, img_apo, imageDown], axis=1)
+
+    imageLeft = img_apo[:, :, 0:napodize, :, :]
+    imageRight = img_apo[:, :, nx-napodize:, :, :]
+    img_apo = img_apo[:, :, napodize:nx-napodize, :, :]
+    diff = (imageRight[:, :, -1::-1, :, :] - imageLeft) / 2
+    fact = fact_raw[np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
+    fact = tf.convert_to_tensor(fact, dtype=tf.float32)
+    fact = tf.tile(fact, [tf.shape(img)[0], ny, 1, nz, ch])
+    factor = diff * fact
+    imageLeft = tf.add(imageLeft, factor)
+    imageRight = tf.subtract(imageRight, factor[:, :, -1::-1, :, :])
+    img_apo = tf.concat([imageLeft, img_apo, imageRight], axis=2)
+
+    return img_apo
+
+
+def pixel_shuffle(layer_in, scale):
+    return tf.nn.depth_to_space(layer_in, block_size=scale)
+
+
+def global_average_pooling2d(layer_in):
+    return tf.reduce_mean(layer_in, axis=(1, 2), keepdims=True)
+
+
+def global_average_pooling3d(layer_in):
+    return tf.reduce_mean(layer_in, axis=(1, 2, 3), keepdims=True)
+
+
+def conv_block2d(input, channel_size):
+    conv = layers.Conv2D(channel_size[0], kernel_size=3, padding='same')(input)
+    conv = layers.LeakyReLU(alpha=0.1)(conv)
+    conv = layers.Conv2D(channel_size[1], kernel_size=3, padding='same')(conv)
+    conv = layers.LeakyReLU(alpha=0.1)(conv)
+    return conv
+
+
+def conv_block3d(input, channel_size):
+    conv = layers.Conv3D(channel_size[0], kernel_size=3, padding='same')(input)
+    conv = layers.LeakyReLU(alpha=0.1)(conv)
+    conv = layers.Conv3D(channel_size[1], kernel_size=3, padding='same')(conv)
+    conv = layers.LeakyReLU(alpha=0.1)(conv)
+    return conv
+
+
+## DFCAN specific methods:
+
+def FCALayer(input, channel, size_psc, reduction=16):
+    absfft1 = layers.Lambda(fft2d, arguments={'gamma': 0.8})(input)
+    absfft1 = layers.Lambda(fftshift2d, arguments={'size_psc': size_psc})(absfft1)
+    absfft2 = layers.Conv2D(channel, kernel_size=3, activation='relu', padding='same')(absfft1)
+    W = layers.Lambda(global_average_pooling2d)(absfft2)
+    W = layers.Conv2D(channel // reduction, kernel_size=1, activation='relu', padding='same')(W)
+    W = layers.Conv2D(channel, kernel_size=1, activation='sigmoid', padding='same')(W)
+    mul = layers.multiply([input, W])
+    return mul
+
+
+def FCAB(input, channel, size_psc):
+    conv = layers.Conv2D(channel, kernel_size=3, padding='same')(input)
+    conv = layers.Lambda(gelu)(conv)
+    conv = layers.Conv2D(channel, kernel_size=3, padding='same')(conv)
+    conv = layers.Lambda(gelu)(conv)
+    att = FCALayer(conv, channel, size_psc=size_psc, reduction=16)
+    output = layers.add([att, input])
+    return output
+
+
+def ResidualGroup(input, channel, size_psc, n_RCAB = 4):
+    conv = input
+    for _ in range(n_RCAB):
+        conv = FCAB(conv, channel=channel, size_psc=size_psc)
+    conv = layers.add([conv, input])
+    return conv
+
+
+def DFCAN(input_shape, scale=4, n_ResGroup = 4, n_RCAB = 4, pretrained_weights=None):
+    inputs = layers.Input(input_shape)
+    size_psc = input_shape[0]
+    conv = layers.Conv2D(64, kernel_size=3, padding='same')(inputs)
+    conv = layers.Lambda(gelu)(conv)
+    for _ in range(n_ResGroup):
+        conv = ResidualGroup(conv, 64, size_psc, n_RCAB = 4)
+    conv = layers.Conv2D(64 * (scale ** 2), kernel_size=3, padding='same')(conv)
+    conv = layers.Lambda(gelu)(conv)
+    upsampled = layers.Lambda(pixel_shuffle, arguments={'scale': scale})(conv)
+    conv = layers.Conv2D(1, kernel_size=3, padding='same')(upsampled)
+    output = layers.Activation('sigmoid')(conv)
+    model = DFCANModel(inputs=inputs, outputs=output)
+    return model
+
+

--- a/models/dfcan.py
+++ b/models/dfcan.py
@@ -86,17 +86,9 @@ class DFCANModel(tf.keras.Model):
                 self.out_dtype = tf.uint16
             self.dtype_not_set = True
 
-## Loss function definition used in the paper from nature methods
-def loss_dfcan(y_true, y_pred):
-  mse = tf.keras.losses.MeanSquaredError()
-  ssim = tf.image.ssim_multiscale(y_true, y_pred, max_val=1)
-  res = mse(y_true, y_pred) + 0.1*(1-ssim)
-  return res
-
 ## DFCAN network definition. We follow the code from:
 ### [Chang Qiao](https://github.com/qc17-THU/DL-SR/tree/main/src) (MIT license).
 #### Common methods for both DFCAN and DFGAN adapted from `common.py`:
-
 
 def gelu(x):
     cdf = 0.5 * (1.0 + tf.math.erf(x / tf.sqrt(2.0)))

--- a/models/rcan.py
+++ b/models/rcan.py
@@ -1,0 +1,199 @@
+import tensorflow as tf
+from tensorflow.keras.layers import Input, Conv2D, Activation, Add, Lambda, GlobalAveragePooling2D, Multiply, Dense, Reshape
+from tensorflow.keras.models import Model
+
+# In order to avoid RecursionError: maximum recursion depth exceeded
+import sys
+sys.setrecursionlimit(10000)
+import warnings
+warnings.filterwarnings('ignore')
+
+class RCANModel(tf.keras.Model):
+    """
+    	Code copied from https://keras.io/examples/vision/edsr
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dtype_not_set = False
+        self.max_value = 255
+        self.out_dtype = tf.uint8
+
+    def train_step(self, data):
+        # Unpack the data. Its structure depends on your model and
+        # on what you pass to `fit()`.
+        x, y = data
+
+        if not self.dtype_not_set:
+            if y.dtype == tf.uint16:
+                self.max_value = 65535 
+            self.out_dtype = y.dtype 
+            self.dtype_not_set = True
+
+        with tf.GradientTape() as tape:
+            y_pred = self(x, training=True)  # Forward pass 
+            y_pred = y_pred*255
+
+            # Compare always in [0-255] range
+            if y.dtype == tf.uint16:
+                y = tf.cast((y/65535)*255, tf.uint8)
+            
+            # Compute the loss value
+            # (the loss function is configured in `compile()`)
+            loss = self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        # Update metrics (includes the metric that tracks the loss)
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value
+        return {m.name: m.result() for m in self.metrics}
+
+    def test_step(self, data):
+        # Unpack the data
+        x, y = data
+        # Compute predictions
+        y_pred = self(x, training=False)
+        y_pred = y_pred*255
+
+        # Compare always in [0-255] range
+        if y.dtype == tf.uint16:
+            y = tf.cast((y/65535)*255, tf.uint8)
+
+        # Updates the metrics tracking the loss
+        self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+        # Update the metrics.
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {m.name: m.result() for m in self.metrics}
+
+    def predict_step(self, x):
+        # Always return the same image dtype and value range of the ground truth
+        # if gt is uint16 -> return uint16 image with values between [0,65535]
+        # if gt is uint8 -> return uint8 image with values between [0,255]
+
+        # Passing low resolution image to model
+        super_resolution_img = self(x, training=False)  
+        super_resolution_img = tf.clip_by_value(super_resolution_img, 0, 1)
+        super_resolution_img = super_resolution_img*self.max_value
+        super_resolution_img = tf.cast(super_resolution_img, self.out_dtype)
+        
+        return super_resolution_img 
+ 
+    def set_dtype(self, img):
+        if not self.dtype_not_set:
+            if img.dtype == np.uint16:
+                self.max_value = 65535
+                self.out_dtype = tf.uint16
+            self.dtype_not_set = True
+
+
+class Mish(tf.keras.layers.Layer):
+  '''
+  Mish Activation Function.
+  .. math::
+      mish(x) = x * tanh(softplus(x)) = x * tanh(ln(1 + e^{x}))
+  Shape:
+      - Input: Arbitrary. Use the keyword argument `input_shape`
+      (tuple of integers, does not include the samples axis)
+      when using this layer as the first layer in a model.
+      - Output: Same shape as the input.
+  Examples:
+      >>> X_input = Input(input_shape)
+      >>> X = Mish()(X_input)
+  '''
+
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+
+  def call(self, inputs):
+    return inputs * tf.math.tanh(tf.math.softplus(inputs))
+
+  def get_config(self):
+    base_config = super().get_config()
+    return {**base_config}
+
+  def compute_output_shape(self, input_shape):
+    return input_shape
+
+
+def sub_pixel_conv2d(scale=2, **kwargs):
+  return Lambda(lambda x: tf.nn.depth_to_space(x, scale), **kwargs)
+
+
+def upsample(input_tensor, filters, use_mish=False):
+  x = Conv2D(filters=filters * 4, kernel_size=3, strides=1, padding='same')(input_tensor)
+  x = sub_pixel_conv2d(scale=2)(x)
+  if use_mish:
+      x = Mish()(x)
+  else:
+      x = Activation('relu')(x)
+  return x
+
+
+def ca(input_tensor, filters, reduce=16, use_mish=False):
+  x = GlobalAveragePooling2D()(input_tensor)
+  x = Reshape((1, 1, filters))(x)
+  if use_mish:
+    x = Dense(filters/reduce, kernel_initializer='he_normal', use_bias=False)(x)
+    x = Mish()(x)
+  else:
+    x = Dense(filters/reduce,  activation='relu', kernel_initializer='he_normal', use_bias=False)(x)
+  x = Dense(filters, activation='sigmoid', kernel_initializer='he_normal', use_bias=False)(x)
+  x = Multiply()([x, input_tensor])
+  return x
+
+
+def rcab(input_tensor, filters, scale=0.1, use_mish=False):
+  x = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(input_tensor)
+  if use_mish:
+    x = Mish()(x)
+  else:
+    x = Activation('relu')(x)
+  x = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(x)
+  x = ca(x, filters, use_mish=use_mish)
+  if scale:
+      x = Lambda(lambda t: t * scale)(x)
+  x = Add()([x, input_tensor])
+
+  return x
+
+
+def rg(input_tensor, filters, n_rcab=20, use_mish=False):
+  x = input_tensor
+  for _ in range(n_rcab):
+    x = rcab(x, filters, use_mish=use_mish)
+  x = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(x)
+  x = Add()([x, input_tensor])
+
+  return x
+
+
+def rir(input_tensor, filters, n_rg=10, use_mish=False):
+    x = input_tensor
+    for _ in range(n_rg):
+        x = rg(x, filters=filters, use_mish=use_mish)
+    x = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(x)
+    x = Add()([x, input_tensor])
+
+    return x
+
+
+def rcan(filters=64, n_sub_block=2, out_channels=1, use_mish=False):
+  inputs = Input(shape=(None, None, out_channels))
+
+  x = x_1 = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(inputs)
+  x = rir(x, filters=filters, use_mish=use_mish)
+  x = Conv2D(filters=filters, kernel_size=3, strides=1, padding='same')(x)
+  x = Add()([x_1, x])
+
+  for _ in range(n_sub_block):
+    x = upsample(x, filters, use_mish=use_mish)
+  x = Conv2D(filters=out_channels, kernel_size=3, strides=1, padding='same')(x)
+
+  return RCANModel(inputs=inputs, outputs=x)
+
+

--- a/models/rcan.py
+++ b/models/rcan.py
@@ -90,6 +90,10 @@ class RCANModel(tf.keras.Model):
                 self.out_dtype = tf.uint16
             self.dtype_not_set = True
 
+## RCAN network definition. We follow the code from:
+### [Hoang Trung Hieu](https://github.com/hieubkset/Keras-Image-Super-Resolution/blob/master/model/rcan.py).
+
+https://github.com/hieubkset/Keras-Image-Super-Resolution/blob/master/model/rcan.py
 
 class Mish(tf.keras.layers.Layer):
   '''

--- a/models/srunet.py
+++ b/models/srunet.py
@@ -1,0 +1,626 @@
+import tensorflow as tf
+import numpy as np
+
+from tensorflow.keras.layers import Dropout, BatchNormalization, SpatialDropout2D
+from tensorflow.keras.layers import Conv2D, Conv2DTranspose, SeparableConv2D
+from tensorflow.keras.layers import Multiply
+from tensorflow.keras.layers import Concatenate, Add, concatenate, Lambda
+from tensorflow.keras.layers import Input, UpSampling2D, Activation
+from tensorflow.keras.layers import AveragePooling2D, MaxPooling2D
+from tensorflow.keras.models import Model
+from tensorflow.nn import depth_to_space
+
+class UnetModel(tf.keras.Model):
+    """
+    	Code copied from https://keras.io/examples/vision/edsr
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dtype_not_set = False
+        self.max_value = 255
+        self.out_dtype = tf.uint8
+
+    def train_step(self, data):
+        # Unpack the data. Its structure depends on your model and
+        # on what you pass to `fit()`.
+        x, y = data
+
+        if not self.dtype_not_set:
+            if y.dtype == tf.uint16:
+                self.max_value = 65535 
+            self.out_dtype = y.dtype 
+            self.dtype_not_set = True
+
+        with tf.GradientTape() as tape:
+            y_pred = self(x, training=True)  # Forward pass 
+            y_pred = y_pred*255
+
+            # Compare always in [0-255] range
+            if y.dtype == tf.uint16:
+                y = tf.cast((y/65535)*255, tf.uint8)
+            
+            # Compute the loss value
+            # (the loss function is configured in `compile()`)
+            loss = self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        # Update metrics (includes the metric that tracks the loss)
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value
+        return {m.name: m.result() for m in self.metrics}
+
+    def test_step(self, data):
+        # Unpack the data
+        x, y = data
+        # Compute predictions
+        y_pred = self(x, training=False)
+        y_pred = y_pred*255
+
+        # Compare always in [0-255] range
+        if y.dtype == tf.uint16:
+            y = tf.cast((y/65535)*255, tf.uint8)
+
+        # Updates the metrics tracking the loss
+        self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+        # Update the metrics.
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {m.name: m.result() for m in self.metrics}
+
+    def predict_step(self, x):
+        # Always return the same image dtype and value range of the ground truth
+        # if gt is uint16 -> return uint16 image with values between [0,65535]
+        # if gt is uint8 -> return uint8 image with values between [0,255]
+
+        # Passing low resolution image to model
+        super_resolution_img = self(x, training=False)  
+        super_resolution_img = tf.clip_by_value(super_resolution_img, 0, 1)
+        super_resolution_img = super_resolution_img*self.max_value
+        super_resolution_img = tf.cast(super_resolution_img, self.out_dtype)
+        
+        return super_resolution_img 
+ 
+    def set_dtype(self, img):
+        if not self.dtype_not_set:
+            if img.dtype == np.uint16:
+                self.max_value = 65535
+                self.out_dtype = tf.uint16
+            self.dtype_not_set = True
+
+
+# Sub-pixel layer for learnable upsampling
+# From: https://github.com/twairball/keras-subpixel-conv/blob/master/subpixel.py
+def SubpixelConv2D(input_shape, scale=4):
+    """
+    Keras layer to do subpixel convolution.
+    NOTE: Tensorflow backend only. Uses tf.depth_to_space
+    Ref:
+        [1] Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network
+            Shi et Al.
+            https://arxiv.org/abs/1609.05158
+    :param input_shape: tensor shape, (batch, height, width, channel)
+    :param scale: upsampling scale. Default=4
+    :return:
+    """
+    # upsample using depth_to_space
+    def subpixel_shape(input_shape):
+        dims = [input_shape[0],
+                input_shape[1] * scale,
+                input_shape[2] * scale,
+                int(input_shape[3] / (scale ** 2))]
+        output_shape = tuple(dims)
+        return output_shape
+
+    def subpixel(x):
+        return depth_to_space(x, scale)
+
+
+    #return Lambda(subpixel, output_shape=subpixel_shape, name='subpixel')
+    return Lambda(subpixel, output_shape=subpixel_shape)
+
+def upsample(x, out_channels=16, method='Upsampling2D', upsampling_factor=2,
+             input_shape=None):
+    if method == 'Conv2DTranspose':
+        if input_shape is None:
+            x = Conv2DTranspose(out_channels, (2, 2),
+                                strides=(upsampling_factor, upsampling_factor),
+                                padding='same') (x)
+        else:
+            x = Conv2DTranspose(out_channels, (2, 2),
+                                strides=(upsampling_factor, upsampling_factor),
+                                padding='same', input_shape=input_shape) (x)
+    elif method == 'Upsampling2D':
+        x = UpSampling2D( size=(upsampling_factor, upsampling_factor) )( x )
+    elif method == 'SubpixelConv2D':
+        x = Conv2D(out_channels * upsampling_factor ** 2, (3, 3),
+                   padding='same')(x)
+        x = SubpixelConv2D( input_shape, scale=upsampling_factor )(x)
+    else:
+        x = UpSampling2D( size=(upsampling_factor, upsampling_factor) )( x )
+
+    return x
+
+def preUNet4(filters=16, input_size = (128,128,1), upsampling_factor=2,
+          spatial_dropout=False, upsample_method='UpSampling2D'):
+
+  inputs = Input( input_size )
+  
+  s = upsample( inputs, out_channels=1, method=upsample_method,
+                     upsampling_factor=upsampling_factor,
+                     input_shape=(input_size[0], input_size[1], input_size[2]))
+
+
+  conv1 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(s)
+  conv1 = SpatialDropout2D(0.1)(conv1) if spatial_dropout else Dropout(0.1) (conv1)
+  conv1 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv1)
+  pool1 = AveragePooling2D(pool_size=(2, 2))(conv1)
+  
+  conv2 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool1)
+  conv2 = SpatialDropout2D(0.1)(conv2) if spatial_dropout else Dropout(0.1) (conv2)
+  conv2 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv2)
+  pool2 = AveragePooling2D(pool_size=(2, 2))(conv2)
+  
+  conv3 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool2)
+  conv3 = SpatialDropout2D(0.2)(conv3) if spatial_dropout else Dropout(0.2) (conv3)
+  conv3 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv3)
+  pool3 = AveragePooling2D(pool_size=(2, 2))(conv3)
+  
+  conv4 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool3)
+  conv4 = SpatialDropout2D(0.2)(conv4) if spatial_dropout else Dropout(0.2)(conv4)
+  conv4 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv4)
+  pool4 = AveragePooling2D(pool_size=(2, 2))(conv4)
+
+  conv5 = Conv2D(filters*16, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool4)
+  conv5 = SpatialDropout2D(0.3)(conv5) if spatial_dropout else Dropout(0.3)(conv5)
+  conv5 = Conv2D(filters*16, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv5)
+  
+  up6 = Conv2DTranspose(filters*8, (2, 2), strides=(2, 2), padding='same') (conv5)
+  merge6 = concatenate([conv4,up6], axis = 3)
+  conv6 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge6)
+  conv6 = SpatialDropout2D(0.2)(conv6) if spatial_dropout else Dropout(0.2)(conv6)
+  conv6 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv6)
+
+  up7 = Conv2DTranspose(filters*4, (2, 2), strides=(2, 2), padding='same') (conv6)
+  merge7 = concatenate([conv3,up7], axis = 3)
+  conv7 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge7)
+  conv7 = SpatialDropout2D(0.2)(conv7) if spatial_dropout else Dropout(0.2)(conv7)
+  conv7 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv7)
+
+  up8 = Conv2DTranspose(filters*2, (2, 2), strides=(2, 2), padding='same') (conv7)
+  merge8 = concatenate([conv2,up8], axis = 3)
+  conv8 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge8)
+  conv8 = SpatialDropout2D(0.1)(conv8) if spatial_dropout else Dropout(0.1)(conv8)
+  conv8 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv8)
+
+  up9 = Conv2DTranspose(filters, (2, 2), strides=(2, 2), padding='same') (conv8)
+  merge9 = concatenate([conv1,up9], axis = 3)
+  conv9 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge9)
+  conv9 = SpatialDropout2D(0.1)(conv9) if spatial_dropout else Dropout(0.1)(conv9)
+  conv9 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv9)
+
+  #outputs = Conv2D(1, (1, 1), activation='sigmoid') (conv9)
+  outputs = Conv2D(1, (1, 1)) (conv9)
+  
+  model = UnetModel(inputs=[inputs], outputs=[outputs])
+  return model
+
+def postUNet4(filters=16, input_size = (128,128,1), upsampling_factor=2,
+          spatial_dropout=False, upsample_method='UpSampling2D'):
+
+  inputs = Input( input_size )
+  
+  conv1 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(inputs)
+  conv1 = SpatialDropout2D(0.1)(conv1) if spatial_dropout else Dropout(0.1) (conv1)
+  conv1 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv1)
+  pool1 = AveragePooling2D(pool_size=(2, 2))(conv1)
+  
+  conv2 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool1)
+  conv2 = SpatialDropout2D(0.1)(conv2) if spatial_dropout else Dropout(0.1) (conv2)
+  conv2 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv2)
+  pool2 = AveragePooling2D(pool_size=(2, 2))(conv2)
+  
+  conv3 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool2)
+  conv3 = SpatialDropout2D(0.2)(conv3) if spatial_dropout else Dropout(0.2) (conv3)
+  conv3 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv3)
+  pool3 = AveragePooling2D(pool_size=(2, 2))(conv3)
+  
+  conv4 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool3)
+  conv4 = SpatialDropout2D(0.2)(conv4) if spatial_dropout else Dropout(0.2)(conv4)
+  conv4 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv4)
+  pool4 = AveragePooling2D(pool_size=(2, 2))(conv4)
+
+  conv5 = Conv2D(filters*16, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(pool4)
+  conv5 = SpatialDropout2D(0.3)(conv5) if spatial_dropout else Dropout(0.3)(conv5)
+  conv5 = Conv2D(filters*16, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv5)
+  
+  up6 = Conv2DTranspose(filters*8, (2, 2), strides=(2, 2), padding='same') (conv5)
+  merge6 = concatenate([conv4,up6], axis = 3)
+  conv6 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge6)
+  conv6 = SpatialDropout2D(0.2)(conv6) if spatial_dropout else Dropout(0.2)(conv6)
+  conv6 = Conv2D(filters*8, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv6)
+
+  up7 = Conv2DTranspose(filters*4, (2, 2), strides=(2, 2), padding='same') (conv6)
+  merge7 = concatenate([conv3,up7], axis = 3)
+  conv7 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge7)
+  conv7 = SpatialDropout2D(0.2)(conv7) if spatial_dropout else Dropout(0.2)(conv7)
+  conv7 = Conv2D(filters*4, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv7)
+
+  up8 = Conv2DTranspose(filters*2, (2, 2), strides=(2, 2), padding='same') (conv7)
+  merge8 = concatenate([conv2,up8], axis = 3)
+  conv8 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge8)
+  conv8 = SpatialDropout2D(0.1)(conv8) if spatial_dropout else Dropout(0.1)(conv8)
+  conv8 = Conv2D(filters*2, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv8)
+
+  up9 = Conv2DTranspose(filters, (2, 2), strides=(2, 2), padding='same') (conv8)
+  merge9 = concatenate([conv1,up9], axis = 3)
+  conv9 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(merge9)
+  conv9 = SpatialDropout2D(0.1)(conv9) if spatial_dropout else Dropout(0.1)(conv9)
+  conv9 = Conv2D(filters, (3,3), activation = 'elu', padding = 'same', kernel_initializer = 'he_normal')(conv9)
+
+  conv9 = upsample( conv9, out_channels=1, method=upsample_method,
+                    upsampling_factor=upsampling_factor,
+                    input_shape=(input_size[0], input_size[1], input_size[2]))
+
+  #outputs = Conv2D(1, (1, 1), activation='sigmoid') (conv9)
+  outputs = Conv2D(1, (1, 1)) (conv9)
+
+  model = UnetModel(inputs=[inputs], outputs=[outputs])
+  return model
+
+# == Residual U-Net ==
+
+def residual_block(x, dim, filter_size, activation='elu', 
+                   kernel_initializer='he_normal', dropout_value=0.2, bn=False,
+                   first_conv_strides=1, separable_conv=False, firstBlock=False):
+
+    # Create shorcut
+    if firstBlock == False:
+        shortcut = Conv2D(dim, activation=None, kernel_size=(1, 1), 
+                      strides=first_conv_strides)(x)
+    else:
+        shortcut = Conv2D(dim, activation=None, kernel_size=(1, 1), 
+                      strides=1)(x)
+    
+    # Main path
+    if firstBlock == False:
+        x = BatchNormalization()(x) if bn else x
+        x = Activation( activation )(x)
+    if separable_conv == False:
+        if firstBlock == True:
+            x = Conv2D(dim, filter_size, strides=1, activation=None,
+                kernel_initializer=kernel_initializer, padding='same') (x)
+        else:
+            x = Conv2D(dim, filter_size, strides=first_conv_strides, activation=None,
+                kernel_initializer=kernel_initializer, padding='same') (x)
+    else:
+        x = SeparableConv2D(dim, filter_size, strides=first_conv_strides, 
+                            activation=None, kernel_initializer=kernel_initializer,
+                            padding='same') (x)
+    x = SpatialDropout2D( dropout_value ) (x) if dropout_value else x
+    x = BatchNormalization()(x) if bn else x
+    x = Activation( activation )(x)
+      
+    if separable_conv == False:
+        x = Conv2D(dim, filter_size, activation=None,
+                kernel_initializer=kernel_initializer, padding='same') (x)
+    else:
+        x = SeparableConv2D(dim, filter_size, activation=None,
+                kernel_initializer=kernel_initializer, padding='same') (x)
+
+    # Add shortcut value to main path
+    x = Add()([shortcut, x])
+    return x
+
+def level_block(x, depth, dim, fs, ac, k, d, bn, fcs, sc, fb, mp):
+
+    if depth > 0:
+        r = residual_block(x, dim, fs, ac, k, d, bn, fcs, sc, fb)
+        x = MaxPooling2D((2, 2)) (r) if mp else r
+        x = level_block(x, depth-1, (dim*2), fs, ac, k, d, bn, fcs, sc, False, mp) 
+        x = Conv2DTranspose(dim, (2, 2), strides=(2, 2), padding='same') (x)
+        x = Concatenate()([r, x])
+        x = residual_block(x, dim, fs, ac, k, d, bn, 1, sc, False)
+    else:
+        x = residual_block(x, dim, fs, ac, k, d, bn, fcs, sc, False)
+    return x
+
+
+def preResUNet(image_shape, activation='elu', kernel_initializer='he_normal',
+            dropout_value=0.2, batchnorm=False, maxpooling=True, separable=False,
+            numInitChannels=16, depth=4, upsampling_factor=2,
+            upsample_method='UpSampling2D', final_activation=None):
+
+    """Create the pre-upsampling ResU-Net for super-resolution
+       Args:
+            image_shape (array of 3 int): dimensions of the input image.
+            activation (str, optional): Keras available activation type.
+            kernel_initializer (str, optional): Keras available kernel 
+            initializer type.
+            dropout_value (real value, optional): dropout value
+            batchnorm (bool, optional): use batch normalization
+            maxpooling (bool, optional): use max-pooling between U-Net levels 
+            (otherwise use stride of 2x2).
+            separable (bool, optional): use SeparableConv2D instead of Conv2D
+            numInitChannels (int, optional): number of channels at the
+            first level of U-Net
+            depth (int, optional): number of U-Net levels
+            upsampling_factor (int, optional): initial image upsampling factor
+            upsample_method (str, optional): upsampling method to use
+            ('UpSampling2D', 'Conv2DTranspose', or 'SubpixelConv2D')
+            final_activation (str, optional): activation function for the last
+            layer
+       Returns:
+            model (Keras model): model containing the ResUNet created.
+    """
+
+    inputs = Input((None, None, image_shape[2]))
+
+    s = upsample( inputs, out_channels=numInitChannels, method=upsample_method,
+                  upsampling_factor=upsampling_factor,
+                  input_shape=(image_shape[0], image_shape[1], image_shape[2]))
+
+    conv_strides = (1,1) if maxpooling else (2,2)
+
+    x = level_block(s, depth, numInitChannels, 3, activation, kernel_initializer,
+                    dropout_value, batchnorm, conv_strides, separable, True,
+                    maxpooling)
+
+    #outputs = Conv2D(1, (1, 1), activation='sigmoid') (x)
+
+    x = Add()([s,x]) # long shortcut
+
+    outputs = Conv2D(image_shape[2], (1, 1), activation=final_activation) (x)
+
+    model = UnetModel(inputs=[inputs], outputs=[outputs])
+
+    return model
+def postResUNet(image_shape, activation='elu', kernel_initializer='he_normal',
+            dropout_value=0.2, batchnorm=False, maxpooling=True, separable=False,
+            numInitChannels=16, depth=4, upsampling_factor=2,
+            upsample_method='UpSampling2D', final_activation=None ):
+
+    """Create the post-upsampling ResU-Net for super-resolution
+       Args:
+            image_shape (array of 3 int): dimensions of the input image.
+            activation (str, optional): Keras available activation type.
+            kernel_initializer (str, optional): Keras available kernel 
+            initializer type.
+            dropout_value (real value, optional): dropout value
+            batchnorm (bool, optional): use batch normalization
+            maxpooling (bool, optional): use max-pooling between U-Net levels 
+            (otherwise use stride of 2x2).
+            separable (bool, optional): use SeparableConv2D instead of Conv2D
+            numInitChannels (int, optional): number of channels at the
+            first level of U-Net
+            depth (int, optional): number of U-Net levels
+            upsampling_factor (int, optional): initial image upsampling factor
+            upsample_method (str, optional): upsampling method to use
+            ('UpSampling2D', 'Conv2DTranspose', or 'SubpixelConv2D')
+            final_activation (str, optional): activation function for the last
+            layer
+       Returns:
+            model (Keras model): model containing the ResUNet created.
+    """
+
+    inputs = Input((None, None, image_shape[2]))
+
+    conv_strides = (1,1) if maxpooling else (2,2)
+
+    x = level_block(inputs, depth, numInitChannels, 3, activation, kernel_initializer,
+                    dropout_value, batchnorm, conv_strides, separable, True,
+                    maxpooling)
+
+    x = upsample( x, out_channels=numInitChannels, method=upsample_method,
+                  upsampling_factor=upsampling_factor,
+                  input_shape=(image_shape[0], image_shape[1], image_shape[2]))
+    
+
+    #outputs = Conv2D(1, (1, 1), activation='sigmoid') (x)
+    outputs = Conv2D(image_shape[2], (1, 1), activation=final_activation) (x)
+
+    model = UnetModel(inputs=[inputs], outputs=[outputs])
+
+    return model
+
+def preAttention_U_Net_2D(image_shape = (None,None,1), activation='elu', feature_maps=[16, 32, 64, 128, 256],
+                       drop_values=[0.1,0.1,0.2,0.2,0.3], spatial_dropout=False, batch_norm=False,
+                       k_init='he_normal',num_outputs=1,pre_load_weights=False,pretrained_model=None,
+                       train_encoder=True,bottleneck_train=True,skip_connection_train=True,
+                       upsampling_factor=2, upsample_method='UpSampling2D'):
+    """Create pre-upsampling 2D U-Net with Attention blocks.
+       Based on `Attention U-Net: Learning Where to Look for the Pancreas <https://arxiv.org/abs/1804.03999>`_.
+       Parameters
+       ----------
+       image_shape : 2D tuple
+           Dimensions of the input image.
+       activation : str, optional
+           Keras available activation type.
+       feature_maps : array of ints, optional
+           Feature maps to use on each level.
+       drop_values : float, optional
+           Dropout value to be fixed. If no value is provided the default behaviour will be to select a piramidal value
+           starting from ``0.1`` and reaching ``0.3`` value.
+       spatial_dropout : bool, optional
+           Use spatial dropout instead of the `normal` dropout.
+       batch_norm : bool, optional
+           Make batch normalization.
+       k_init : string, optional
+           Kernel initialization for convolutional layers.
+       n_classes: int, optional
+           Number of classes.
+       Returns
+       -------
+       model : Keras model
+           Model containing the Attention U-Net.
+       Example
+       -------
+       Calling this function with its default parameters returns the following network:
+       .. image:: ../img/unet.png
+           :width: 100%
+           :align: center
+       Image created with `PlotNeuralNet <https://github.com/HarisIqbal88/PlotNeuralNet>`_.
+       That networks incorporates in skip connecions Attention Gates (AG), which
+       can be seen as follows:
+       .. image:: ../img/attention_gate.png
+           :width: 100%
+           :align: center
+       Image extracted from `Attention U-Net: Learning Where to Look for the Pancreas <https://arxiv.org/abs/1804.03999>`_.
+    """
+
+    if len(feature_maps) != len(drop_values):
+        raise ValueError("'feature_maps' dimension must be equal 'drop_values' dimension")
+    depth = len(feature_maps)-1
+
+    inputs = Input((None, None, image_shape[2]))
+
+    x = upsample( inputs, out_channels=num_outputs, method=upsample_method,
+                  upsampling_factor=upsampling_factor,
+                  input_shape=(image_shape[0], image_shape[1], image_shape[2]))
+    
+    # List used to access layers easily to make the skip connections of the U-Net
+    l=[]
+
+    # ENCODER
+    for i in range(depth):
+        x = Conv2D(feature_maps[i], (3, 3), activation=None, kernel_initializer=k_init, padding='same',trainable=train_encoder) (x)
+        x = BatchNormalization(trainable=train_encoder) (x) if batch_norm else x
+        x = Activation(activation,trainable=train_encoder) (x)
+        if drop_values is not None:
+            if spatial_dropout:
+                x = SpatialDropout2D(drop_values[i],trainable=train_encoder) (x)
+            else:
+                x = Dropout(drop_values[i],trainable=train_encoder) (x)
+        x = Conv2D(feature_maps[i], (3, 3), activation=None, kernel_initializer=k_init, padding='same',trainable=train_encoder) (x)
+        x = BatchNormalization(trainable=train_encoder) (x) if batch_norm else x
+        x = Activation(activation,trainable=train_encoder) (x)
+
+        l.append(x)
+
+        x = MaxPooling2D((2, 2),trainable=train_encoder)(x)
+      
+    
+    # BOTTLENECK
+    x = Conv2D(feature_maps[depth], (3, 3), activation=None, kernel_initializer=k_init, padding='same',trainable=bottleneck_train)(x)
+    x = BatchNormalization(trainable=bottleneck_train) (x) if batch_norm else x
+    x = Activation(activation,trainable=bottleneck_train) (x)
+    if drop_values is not None:
+            if spatial_dropout:
+                x = SpatialDropout2D(drop_values[depth],trainable=bottleneck_train) (x)
+            else:
+                x = Dropout(drop_values[depth],trainable=bottleneck_train) (x)
+    x = Conv2D(feature_maps[depth], (3, 3), activation=None, kernel_initializer=k_init, padding='same',trainable=bottleneck_train) (x)
+    x = BatchNormalization(trainable=bottleneck_train) (x) if batch_norm else x
+    x = Activation(activation,trainable=bottleneck_train) (x)
+   
+    # DECODER
+    for i in range(depth-1, -1, -1):
+        x = Conv2DTranspose(feature_maps[i], (2, 2), strides=(2, 2), padding='same') (x)
+        attn = AttentionBlock(x, l[i], feature_maps[i], batch_norm,trainable=skip_connection_train)
+        x = concatenate([x, attn])
+        x = Conv2D(feature_maps[i], (3, 3), activation=None, kernel_initializer=k_init, padding='same') (x)
+        x = BatchNormalization() (x) if batch_norm else x
+        x = Activation(activation) (x)
+        if drop_values is not None:
+            if spatial_dropout:
+                x = SpatialDropout2D(drop_values[i]) (x)
+            else:
+                x = Dropout(drop_values[i]) (x)
+
+        x = Conv2D(feature_maps[i], (3, 3), activation=None, kernel_initializer=k_init, padding='same') (x)
+        x = BatchNormalization() (x) if batch_norm else x
+        x = Activation(activation) (x)
+
+
+    outputs = Conv2D( num_outputs, (1, 1), activation='linear') (x)
+    '''
+    if num_outputs==1:
+         outputs = Conv2D( num_outputs, (1, 1), activation='sigmoid') (x)
+    else:
+         outputs = Conv2D( num_outputs, (1, 1), activation='softmax') (x)
+    '''
+    
+
+    model = UnetModel(inputs=[inputs], outputs=[outputs])
+    if pre_load_weights:
+        #Loading weights layer by layer except from the last layer whose structure would change 
+    
+        for i in range((len(model.layers)-1)):
+            model.get_layer(index=i).set_weights(pretrained_model.get_layer(index=i).get_weights())
+
+    return model
+
+
+def AttentionBlock(x, shortcut, filters, batch_norm,trainable=False):
+    """Attention block.
+       Extracted from `Kaggle <https://www.kaggle.com/c/tgs-salt-identification-challenge/discussion/64367>`_.
+       Parameters
+       ----------
+       x : Keras layer
+           Input layer.
+       shortcut : Keras layer
+           Input skip connection.
+       filters : int
+           Feature maps to define on the Conv layers.
+       batch_norm : bool, optional
+           To use batch normalization.
+       Returns
+       -------
+       out : Keras layer
+           Last layer of the Attention block.
+    """
+    g1 = Conv2D(filters, kernel_size = 1,trainable=trainable)(shortcut)
+    g1 = BatchNormalization(trainable=trainable) (g1) if batch_norm else g1
+    x1 = Conv2D(filters, kernel_size = 1,trainable=trainable)(x)
+    x1 = BatchNormalization(trainable=trainable) (x1) if batch_norm else x1
+
+    g1_x1 = Add(trainable=trainable)([g1,x1])
+    psi = Activation('relu',trainable=trainable)(g1_x1)
+    psi = Conv2D(1, kernel_size = 1,trainable=trainable)(psi)
+    psi = BatchNormalization(trainable=trainable) (psi) if batch_norm else psi
+    psi = Activation('sigmoid',trainable=trainable)(psi)
+    x = Multiply(trainable=trainable)([x,psi])
+    
+    return x    
+
+######
+
+def pad_images_for_Unet(lr_imgs, hr_imgs, depth_Unet, is_pre, scale):
+  
+  lr_height = lr_imgs[0].shape[0]
+  lr_width = lr_imgs[0].shape[1]
+
+  if is_pre:
+    lr_height *= scale
+    lr_width *= scale
+
+  if lr_width%2**depth_Unet != 0 or lr_height%2**depth_Unet != 0:
+    height_gap = ((lr_height//2**depth_Unet) + 1) * 2**depth_Unet - lr_height
+    width_gap = ((lr_width//2**depth_Unet) + 1) * 2**depth_Unet - lr_width
+
+    if is_pre:
+      height_gap //= 2
+      width_gap //= 2
+
+    height_padding = (height_gap//2 + height_gap%2, height_gap//2)
+    width_padding = (width_gap//2 + width_gap%2, width_gap//2)
+
+    if is_pre:
+      if height_gap == 1:
+        height_padding = (height_gap, 0)
+      if width_gap == 1:
+        width_padding = (width_gap, 0)
+
+    lr_imgs = [np.pad(x, (height_padding, width_padding,(0,0)), mode="constant", constant_values=0) for x in lr_imgs]
+
+    hr_height_padding = (height_padding[0] * 2, height_padding[1] * 2)
+    hr_width_padding = (width_padding[0] * 2, width_padding[1] * 2)
+
+    hr_imgs = [np.pad(x, (hr_height_padding, hr_width_padding, (0,0)), mode="constant", constant_values=0) for x in hr_imgs]
+
+  return np.array(lr_imgs), np.array(hr_imgs)
+

--- a/models/wdsr.py
+++ b/models/wdsr.py
@@ -1,0 +1,143 @@
+import tensorflow as tf
+from tensorflow.keras.layers import Add, Input, Lambda
+from tensorflow.keras.models import Model
+import tensorflow_addons as tfa
+
+
+class WDSRModel(tf.keras.Model):
+    """
+    	Code copied from https://keras.io/examples/vision/edsr
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dtype_not_set = False
+        self.max_value = 255
+        self.out_dtype = tf.uint8
+
+    def train_step(self, data):
+        # Unpack the data. Its structure depends on your model and
+        # on what you pass to `fit()`.
+        x, y = data
+
+        if not self.dtype_not_set:
+            if y.dtype == tf.uint16:
+                self.max_value = 65535 
+            self.out_dtype = y.dtype 
+            self.dtype_not_set = True
+
+        with tf.GradientTape() as tape:
+            y_pred = self(x, training=True)  # Forward pass 
+            y_pred = y_pred*255
+
+            # Compare always in [0-255] range
+            if y.dtype == tf.uint16:
+                y = tf.cast((y/65535)*255, tf.uint8)
+            
+            # Compute the loss value
+            # (the loss function is configured in `compile()`)
+            loss = self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        # Update metrics (includes the metric that tracks the loss)
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value
+        return {m.name: m.result() for m in self.metrics}
+
+    def test_step(self, data):
+        # Unpack the data
+        x, y = data
+        # Compute predictions
+        y_pred = self(x, training=False)
+        y_pred = y_pred*255
+
+        # Compare always in [0-255] range
+        if y.dtype == tf.uint16:
+            y = tf.cast((y/65535)*255, tf.uint8)
+
+        # Updates the metrics tracking the loss
+        self.compiled_loss(y, y_pred, regularization_losses=self.losses)
+        # Update the metrics.
+        self.compiled_metrics.update_state(y, y_pred)
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {m.name: m.result() for m in self.metrics}
+
+    def predict_step(self, x):
+        # Always return the same image dtype and value range of the ground truth
+        # if gt is uint16 -> return uint16 image with values between [0,65535]
+        # if gt is uint8 -> return uint8 image with values between [0,255]
+
+        # Passing low resolution image to model
+        super_resolution_img = self(x, training=False)  
+        super_resolution_img = tf.clip_by_value(super_resolution_img, 0, 1)
+        super_resolution_img = super_resolution_img*self.max_value
+        super_resolution_img = tf.cast(super_resolution_img, self.out_dtype)
+        
+        return super_resolution_img 
+ 
+    def set_dtype(self, img):
+        if not self.dtype_not_set:
+            if img.dtype == np.uint16:
+                self.max_value = 65535
+                self.out_dtype = tf.uint16
+            self.dtype_not_set = True
+
+
+def subpixel_conv2d(scale):
+    return lambda x: tf.nn.depth_to_space(x, scale)
+
+
+def wdsr_a(scale, num_filters=32, num_res_blocks=8, res_block_expansion=4, res_block_scaling=None, out_channels=1):
+    return wdsr(scale, num_filters, num_res_blocks, res_block_expansion, res_block_scaling, res_block_a, out_channels)
+
+
+def wdsr_b(scale, num_filters=32, num_res_blocks=8, res_block_expansion=6, res_block_scaling=None, out_channels=1):
+    return wdsr(scale, num_filters, num_res_blocks, res_block_expansion, res_block_scaling, res_block_b, out_channels)
+
+
+def wdsr(scale, num_filters, num_res_blocks, res_block_expansion, res_block_scaling, res_block, out_channels=1):
+    x_in = Input(shape=(None, None, out_channels))
+    x = x_in
+    # main branch
+    m = conv2d_weightnorm(num_filters, 3, padding='same')(x)
+    for i in range(num_res_blocks):
+        m = res_block(m, num_filters, res_block_expansion, kernel_size=3, scaling=res_block_scaling)
+    m = conv2d_weightnorm(out_channels * scale ** 2, 3, padding='same', name=f'conv2d_main_scale_{scale}')(m)
+    m = Lambda(subpixel_conv2d(scale))(m)
+
+    # skip branch
+    s = conv2d_weightnorm(out_channels * scale ** 2, 5, padding='same', name=f'conv2d_skip_scale_{scale}')(x)
+    s = Lambda(subpixel_conv2d(scale))(s)
+
+    x = Add()([m, s])
+    # final convolution with sigmoid activation ?
+    #x = Conv2D(out_channels, 3, padding='same', activation='sigmoid')(x)
+
+    return WDSRModel(x_in, x, name="wdsr")
+
+
+def res_block_a(x_in, num_filters, expansion, kernel_size, scaling):
+    x = conv2d_weightnorm(num_filters * expansion, kernel_size, padding='same', activation='relu')(x_in)
+    x = conv2d_weightnorm(num_filters, kernel_size, padding='same')(x)
+    if scaling:
+        x = Lambda(lambda t: t * scaling)(x)
+    x = Add()([x_in, x])
+    return x
+
+
+def res_block_b(x_in, num_filters, expansion, kernel_size, scaling):
+    linear = 0.8
+    x = conv2d_weightnorm(num_filters * expansion, 1, padding='same', activation='relu')(x_in)
+    x = conv2d_weightnorm(int(num_filters * linear), 1, padding='same')(x)
+    x = conv2d_weightnorm(num_filters, kernel_size, padding='same')(x)
+    if scaling:
+        x = Lambda(lambda t: t * scaling)(x)
+    x = Add()([x_in, x])
+    return x
+
+def conv2d_weightnorm(filters, kernel_size, padding='same', activation=None, **kwargs):
+    return tfa.layers.WeightNormalization(tf.keras.layers.Conv2D(filters, kernel_size, padding=padding, activation=activation, **kwargs), data_init=False)

--- a/models/wdsr.py
+++ b/models/wdsr.py
@@ -87,6 +87,9 @@ class WDSRModel(tf.keras.Model):
             self.dtype_not_set = True
 
 
+## RCAN network definition. We follow the code from:
+### [Martin Krasser](http://krasserm.github.io/2019/09/04/super-resolution/).
+
 def subpixel_conv2d(scale):
     return lambda x: tf.nn.depth_to_space(x, scale)
 

--- a/templates/super-resolution/dfcan_super-resolution.yaml
+++ b/templates/super-resolution/dfcan_super-resolution.yaml
@@ -1,0 +1,47 @@
+SYSTEM:
+    NUM_CPUS: 1
+
+PROBLEM:
+    TYPE: SUPER_RESOLUTION
+    NDIM: 2D
+    SUPER_RESOLUTION:
+        UPSCALING: 2
+  
+DATA: 
+    PATCH_SIZE: (24, 24, 1)
+    CHECK_GENERATORS: False
+    TRAIN:                                                                                                              
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        IN_MEMORY: True
+    VAL:
+        SPLIT_TRAIN: 0.1
+    TEST:                                                                                                               
+        IN_MEMORY: True
+        LOAD_GT: True
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        PADDING: (8,8)
+
+AUGMENTOR:
+    ENABLE: True
+    DA_PROB: 0.5
+    VFLIP: True
+    HFLIP: True
+    ROT90: True
+
+MODEL:
+    ARCHITECTURE: dfcan
+    LOAD_CHECKPOINT: False
+
+TRAIN:
+    ENABLE: True
+    OPTIMIZER: ADAM
+    LR: 5.E-5
+    BATCH_SIZE: 16
+    EPOCHS: 2
+    PATIENCE: 2
+  
+TEST:
+    ENABLE: True
+    AUGMENTATION: False

--- a/templates/super-resolution/dfcan_super-resolution.yaml
+++ b/templates/super-resolution/dfcan_super-resolution.yaml
@@ -38,9 +38,9 @@ TRAIN:
     ENABLE: True
     OPTIMIZER: ADAM
     LR: 5.E-5
-    BATCH_SIZE: 16
-    EPOCHS: 2
-    PATIENCE: 2
+    BATCH_SIZE: 12
+    EPOCHS: 400
+    PATIENCE: 50
   
 TEST:
     ENABLE: True

--- a/templates/super-resolution/rcan_super-resolution.yaml
+++ b/templates/super-resolution/rcan_super-resolution.yaml
@@ -1,0 +1,47 @@
+SYSTEM:
+    NUM_CPUS: 1
+
+PROBLEM:
+    TYPE: SUPER_RESOLUTION
+    NDIM: 2D
+    SUPER_RESOLUTION:
+        UPSCALING: 2
+  
+DATA: 
+    PATCH_SIZE: (24, 24, 1)
+    CHECK_GENERATORS: False
+    TRAIN:                                                                                                              
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        IN_MEMORY: True
+    VAL:
+        SPLIT_TRAIN: 0.1
+    TEST:                                                                                                               
+        IN_MEMORY: True
+        LOAD_GT: True
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        PADDING: (8,8)
+
+AUGMENTOR:
+    ENABLE: True
+    DA_PROB: 0.5
+    VFLIP: True
+    HFLIP: True
+    ROT90: True
+
+MODEL:
+    ARCHITECTURE: rcan
+    LOAD_CHECKPOINT: False
+
+TRAIN:
+    ENABLE: True
+    OPTIMIZER: ADAM
+    LR: 5.E-5
+    BATCH_SIZE: 16
+    EPOCHS: 2
+    PATIENCE: 2
+  
+TEST:
+    ENABLE: True
+    AUGMENTATION: False

--- a/templates/super-resolution/rcan_super-resolution.yaml
+++ b/templates/super-resolution/rcan_super-resolution.yaml
@@ -38,9 +38,9 @@ TRAIN:
     ENABLE: True
     OPTIMIZER: ADAM
     LR: 5.E-5
-    BATCH_SIZE: 16
-    EPOCHS: 2
-    PATIENCE: 2
+    BATCH_SIZE: 12
+    EPOCHS: 400
+    PATIENCE: 50
   
 TEST:
     ENABLE: True

--- a/templates/super-resolution/srunet_super-resolution.yaml
+++ b/templates/super-resolution/srunet_super-resolution.yaml
@@ -1,0 +1,47 @@
+SYSTEM:
+    NUM_CPUS: 1
+
+PROBLEM:
+    TYPE: SUPER_RESOLUTION
+    NDIM: 2D
+    SUPER_RESOLUTION:
+        UPSCALING: 2
+  
+DATA: 
+    PATCH_SIZE: (24, 24, 1)
+    CHECK_GENERATORS: False
+    TRAIN:                                                                                                              
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        IN_MEMORY: True
+    VAL:
+        SPLIT_TRAIN: 0.1
+    TEST:                                                                                                               
+        IN_MEMORY: True
+        LOAD_GT: True
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        PADDING: (8,8)
+
+AUGMENTOR:
+    ENABLE: True
+    DA_PROB: 0.5
+    VFLIP: True
+    HFLIP: True
+    ROT90: True
+
+MODEL:
+    ARCHITECTURE: srunet
+    LOAD_CHECKPOINT: False
+
+TRAIN:
+    ENABLE: True
+    OPTIMIZER: ADAM
+    LR: 5.E-5
+    BATCH_SIZE: 16
+    EPOCHS: 2
+    PATIENCE: 2
+  
+TEST:
+    ENABLE: True
+    AUGMENTATION: False

--- a/templates/super-resolution/srunet_super-resolution.yaml
+++ b/templates/super-resolution/srunet_super-resolution.yaml
@@ -38,9 +38,9 @@ TRAIN:
     ENABLE: True
     OPTIMIZER: ADAM
     LR: 5.E-5
-    BATCH_SIZE: 16
-    EPOCHS: 2
-    PATIENCE: 2
+    BATCH_SIZE: 12
+    EPOCHS: 400
+    PATIENCE: 50
   
 TEST:
     ENABLE: True

--- a/templates/super-resolution/wdsr_super-resolution.yaml
+++ b/templates/super-resolution/wdsr_super-resolution.yaml
@@ -1,0 +1,47 @@
+SYSTEM:
+    NUM_CPUS: 1
+
+PROBLEM:
+    TYPE: SUPER_RESOLUTION
+    NDIM: 2D
+    SUPER_RESOLUTION:
+        UPSCALING: 2
+  
+DATA: 
+    PATCH_SIZE: (24, 24, 1)
+    CHECK_GENERATORS: False
+    TRAIN:                                                                                                              
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        IN_MEMORY: True
+    VAL:
+        SPLIT_TRAIN: 0.1
+    TEST:                                                                                                               
+        IN_MEMORY: True
+        LOAD_GT: True
+        PATH: /path/to/data
+        MASK_PATH: /path/to/data
+        PADDING: (8,8)
+
+AUGMENTOR:
+    ENABLE: True
+    DA_PROB: 0.5
+    VFLIP: True
+    HFLIP: True
+    ROT90: True
+
+MODEL:
+    ARCHITECTURE: wdsr
+    LOAD_CHECKPOINT: False
+
+TRAIN:
+    ENABLE: True
+    OPTIMIZER: ADAM
+    LR: 5.E-5
+    BATCH_SIZE: 16
+    EPOCHS: 2
+    PATIENCE: 2
+  
+TEST:
+    ENABLE: True
+    AUGMENTATION: False

--- a/templates/super-resolution/wdsr_super-resolution.yaml
+++ b/templates/super-resolution/wdsr_super-resolution.yaml
@@ -38,9 +38,9 @@ TRAIN:
     ENABLE: True
     OPTIMIZER: ADAM
     LR: 5.E-5
-    BATCH_SIZE: 16
-    EPOCHS: 2
-    PATIENCE: 2
+    BATCH_SIZE: 12
+    EPOCHS: 400
+    PATIENCE: 50
   
 TEST:
     ENABLE: True


### PR DESCRIPTION
Four super-resolution models have been introduced: SR-Unet, RCAN, DFCAN and WDSR.

The changes that have been applied are:

- engine: 
    - _init_.py: introduce the DFCAN loss to the compile function in super-resolution section.
    - metrics.py: implement the DFCAN loss.
    - check_configuration.py: introduce the models' names to check they are super-resolution models.
- models: 
    - _init_.py: introduce the models' names and their architectures' initialization.
    - The architectures from all the models have been introduced: srunet.py, rcan.py, dfcan.py, wdsr.py
- templates: 
    - super_resolution:
        - The templates from all the models have been introduced: srunet_super-resolution.yaml, rcan_super-resolution.yaml, dfcan_super-resolution.yaml, wdsr_super-resolution.yaml

Also, due to the dependencies in wdsr.py, the following library should be introduced:
`pip install tensorflow-addons==0.15.0`